### PR TITLE
fixed mail throwing errors on 'of the x' type items

### DIFF
--- a/ElvUI/Modules/Skins/Blizzard/Mail.lua
+++ b/ElvUI/Modules/Skins/Blizzard/Mail.lua
@@ -51,10 +51,8 @@ local function LoadSkin()
 
 				button:SetBackdropBorderColor(unpack(E["media"].bordercolor))
 				if packageIcon and not isGM then
-					local itemName = GetInboxItem(index)
+					local itemName, _, _, quality = GetInboxItem(index)
 					if itemName then
-						local _, itemString = GetItemInfoByName(itemName)
-						local _, _, quality = GetItemInfo(itemString, "item:(%d+)")
 						if quality then
 							button:SetBackdropBorderColor(GetItemQualityColor(quality))
 						else

--- a/ElvUI/Modules/Skins/Blizzard/Mail.lua
+++ b/ElvUI/Modules/Skins/Blizzard/Mail.lua
@@ -165,10 +165,8 @@ local function LoadSkin()
 		local _, stationeryIcon, _, _, _, _, _, hasItem = GetInboxHeaderInfo(index)
 
 		if hasItem then
-			local itemName = GetInboxItem(index)
+			local itemName, _, _, quality = GetInboxItem(index)
 			if itemName then
-				local _, itemString = GetItemInfoByName(itemName)
-				local _, _, quality = GetItemInfo(itemString, "item:(%d+)")
 				if quality then
 					OpenMailPackageButton:SetBackdropBorderColor(GetItemQualityColor(quality))
 				else


### PR DESCRIPTION
Not positive if the existing GetItemInfoByName was necessary or not but this fixes items with an 'of the x' name returning nil and seems to have caused no other problems.

http://vanilla-wow.wikia.com/wiki/API_GetInboxItem
i assume since it's a backport and the function was broken in 2.3 to give the wrong quality thats why it exists but I don't think it's necessary in 1.12.1