### PR TITLE
override RAID_CLASS_COLORS to 2.0+ values

### DIFF
--- a/ElvUI/Core/core.lua
+++ b/ElvUI/Core/core.lua
@@ -23,7 +23,6 @@ local SendAddonMessage = SendAddonMessage
 local CUSTOM_CLASS_COLORS = CUSTOM_CLASS_COLORS
 local ERR_NOT_IN_COMBAT = ERR_NOT_IN_COMBAT
 local MAX_TALENT_TABS = MAX_TALENT_TABS
-local RAID_CLASS_COLORS = RAID_CLASS_COLORS
 
 _, E.myclass = UnitClass("player") -- Constants
 _, E.myrace = UnitRace("player")

--- a/ElvUI/Core/core.lua
+++ b/ElvUI/Core/core.lua
@@ -133,6 +133,18 @@ E.DEFAULT_FILTER = {
 	["RaidDebuffs"] = "Whitelist",
 }
 
+RAID_CLASS_COLORS = {
+	["HUNTER"] = { r = 0.67, g = 0.83, b = 0.45, colorStr = "ffabd473" },
+	["WARLOCK"] = { r = 0.53, g = 0.53, b = 0.93, colorStr = "ff8788ee" },
+	["PRIEST"] = { r = 1.0, g = 1.0, b = 1.0, colorStr = "ffffffff" },
+	["PALADIN"] = { r = 0.96, g = 0.55, b = 0.73, colorStr = "fff58cba" },
+	["MAGE"] = { r = 0.25, g = 0.78, b = 0.92, colorStr = "ff3fc7eb" },
+	["ROGUE"] = { r = 1.0, g = 0.96, b = 0.41, colorStr = "fffff569" },
+	["DRUID"] = { r = 1.0, g = 0.49, b = 0.04, colorStr = "ffff7d0a" },
+	["SHAMAN"] = { r = 0.0, g = 0.44, b = 0.87, colorStr = "ff0070de" },
+	["WARRIOR"] = { r = 0.78, g = 0.61, b = 0.43, colorStr = "ffc79c6e" },
+};
+
 E.noop = function() end
 
 local colorizedName


### PR DESCRIPTION
Not necessarily a fix for anything, but it feels out of place having the class colors (mainly shaman) not changed by the UI to the 2.0+ ones. Other UIs (pfUI mainly) replace RAID_CLASS_COLORS as well. 

Might be out of scope for this UI and there is other addons that changes it already,